### PR TITLE
fix: remove ssh key type check since its failing and not needed

### DIFF
--- a/tap_mysql/tap.py
+++ b/tap_mysql/tap.py
@@ -273,7 +273,7 @@ class TapMySQL(SQLTap):
         self.ssh_tunnel: SSHTunnelForwarder = SSHTunnelForwarder(
             ssh_address_or_host=(ssh_config["host"], ssh_config["port"]),
             ssh_username=ssh_config["username"],
-            ssh_private_key=self.guess_key_type(ssh_config["private_key"]),
+            ssh_private_key=ssh_config["private_key"],
             ssh_private_key_password=ssh_config.get("private_key_password"),
             remote_bind_address=(url.host, url.port),
         )


### PR DESCRIPTION
Key type check is failing for GCP generated keys, but passing the key as-is works fine.